### PR TITLE
Change the crate name to match Rust's naming conventions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "SimpleBackup"
+name = "simple_backup"
 version = "0.1.0"
 edition = "2021"
 build = "build.rs"


### PR DESCRIPTION
Fixes #3